### PR TITLE
Switched bs3 widget to bs4

### DIFF
--- a/src/AlertBlock.php
+++ b/src/AlertBlock.php
@@ -11,7 +11,7 @@ namespace kartik\alert;
 
 use Yii;
 use yii\base\InvalidConfigException;
-use yii\bootstrap\Widget;
+use yii\bootstrap4\Widget;
 use yii\helpers\Html;
 use yii\helpers\ArrayHelper;
 use kartik\base\Config;


### PR DESCRIPTION
## Scope
This pull request includes a

- [X] Bug fix

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-widget-alert/blob/master/CHANGE.md)):

- AlertBlock class was using ``yii\bootstrap\Widget``  as dependecy instead of ``yii\bootstrap4\Widget`` 
